### PR TITLE
Fix Server.Stop double close bug

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -3,11 +3,13 @@ package server
 import (
 	"net"
 	"strconv"
+	"sync"
 )
 
 type Server struct {
 	listeners    []*Listener
 	closeChannel chan int
+	stopOnce     sync.Once
 }
 
 type ConnectionType string
@@ -32,12 +34,14 @@ func NewServer(listeners []*Listener) *Server {
 	return &Server{
 		listeners:    listeners,
 		closeChannel: make(chan int),
+		stopOnce:     sync.Once{},
 	}
 }
 
 func (s *Server) Stop() {
-	s.closeChannel <- 0
-	close(s.closeChannel)
+	s.stopOnce.Do(func() {
+		close(s.closeChannel)
+	})
 }
 
 func (s *Server) Start() {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,15 @@
+package server
+
+import "testing"
+
+func TestServerStopIdempotent(t *testing.T) {
+	s := NewServer([]*Listener{})
+	// call Stop multiple times; should not panic
+	s.Stop()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Stop panicked on second call: %v", r)
+		}
+	}()
+	s.Stop()
+}


### PR DESCRIPTION
## Summary
- prevent panic on repeated Server.Stop calls by using sync.Once
- add regression test for Server.Stop idempotency

## Testing
- `go test ./...` *(fails: fetching modules requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_685ed807775c8333a738590b04040379