### PR TITLE
Add stigma in-memory engine scaffolding

### DIFF
--- a/stigma/cellindex.go
+++ b/stigma/cellindex.go
@@ -1,0 +1,49 @@
+package stigma
+
+import (
+	"errors"
+	"math"
+)
+
+// CellIndex maps lat/lon coordinates to deterministic CellIDs.
+type CellIndex struct{}
+
+// NewCellIndex constructs a CellIndex.
+func NewCellIndex() *CellIndex {
+	return &CellIndex{}
+}
+
+// CellForCoord converts a coordinate into a CellID for the given resolution.
+// This is a placeholder grid; the API mirrors an H3-based implementation.
+func (c *CellIndex) CellForCoord(lat, lon float64, res Resolution) (CellID, error) {
+	if math.IsNaN(lat) || math.IsNaN(lon) || math.IsInf(lat, 0) || math.IsInf(lon, 0) {
+		return 0, errors.New("invalid coordinate")
+	}
+
+	factor := math.Pow(2, float64(res)+1) // higher resolution => finer grid
+	x := int64(math.Floor((lon + 180.0) * factor))
+	y := int64(math.Floor((lat + 90.0) * factor))
+	return CellID(uint64(y)<<32 | uint64(x&0xffffffff)), nil
+}
+
+// CellsInBBox returns all cells intersecting the bounding box for the resolution.
+func (c *CellIndex) CellsInBBox(minLat, minLon, maxLat, maxLon float64, res Resolution) ([]CellID, error) {
+	if minLat > maxLat || minLon > maxLon {
+		return nil, errors.New("invalid bounding box")
+	}
+
+	factor := math.Pow(2, float64(res)+1)
+	minX := int64(math.Floor((minLon + 180.0) * factor))
+	maxX := int64(math.Floor((maxLon + 180.0) * factor))
+	minY := int64(math.Floor((minLat + 90.0) * factor))
+	maxY := int64(math.Floor((maxLat + 90.0) * factor))
+
+	var cells []CellID
+	for y := minY; y <= maxY; y++ {
+		for x := minX; x <= maxX; x++ {
+			cells = append(cells, CellID(uint64(y)<<32|uint64(x&0xffffffff)))
+		}
+	}
+
+	return cells, nil
+}

--- a/stigma/engine.go
+++ b/stigma/engine.go
@@ -1,0 +1,190 @@
+package stigma
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"time"
+)
+
+// EngineConfig configures the stigma engine.
+type EngineConfig struct {
+	DefaultResolution Resolution
+	MinResolution     Resolution
+	MaxResolution     Resolution
+
+	WALPath       string
+	SnapshotPath  string
+	FlushInterval time.Duration
+}
+
+// Engine aggregates ingest, query, and persistence logic.
+// Engine is NOT safe for concurrent use by multiple goroutines in v1.
+type Engine struct {
+	cfg         EngineConfig
+	cellIndex   *CellIndex
+	nodes       *NodeStore
+	transitions *TransitionStore
+	states      *EntityStateStore
+	wal         *WAL
+}
+
+// NewEngine creates a new Engine and replays any WAL if present.
+func NewEngine(cfg EngineConfig) (*Engine, error) {
+	e := &Engine{
+		cfg:         cfg,
+		cellIndex:   NewCellIndex(),
+		nodes:       NewNodeStore(),
+		transitions: NewTransitionStore(),
+		states:      NewEntityStateStore(),
+	}
+
+	if cfg.WALPath != "" {
+		wal, err := OpenWAL(cfg.WALPath)
+		if err != nil {
+			return nil, fmt.Errorf("open wal: %w", err)
+		}
+		e.wal = wal
+		if err := e.replayWAL(); err != nil {
+			return nil, err
+		}
+	}
+
+	return e, nil
+}
+
+// Close flushes and closes any persistence layers.
+func (e *Engine) Close() error {
+	if e.wal != nil {
+		return e.wal.Close()
+	}
+	return nil
+}
+
+func (e *Engine) clampResolution(res Resolution) Resolution {
+	if e.cfg.MinResolution != 0 && res < e.cfg.MinResolution {
+		return e.cfg.MinResolution
+	}
+	if e.cfg.MaxResolution != 0 && res > e.cfg.MaxResolution {
+		return e.cfg.MaxResolution
+	}
+	return res
+}
+
+// IngestSample processes a single sample.
+func (e *Engine) IngestSample(sample LocationSample) error {
+	return e.ingest([]LocationSample{sample}, true)
+}
+
+func validateSample(s LocationSample) error {
+	if s.EntityID == "" {
+		return errors.New("entity id is required")
+	}
+	if math.IsNaN(s.Lat) || math.IsNaN(s.Lon) || s.Lat < -90 || s.Lat > 90 || s.Lon < -180 || s.Lon > 180 {
+		return errors.New("invalid coordinates")
+	}
+	if s.Timestamp.IsZero() {
+		return errors.New("timestamp is required")
+	}
+	return nil
+}
+
+// IngestBatch processes multiple samples efficiently.
+func (e *Engine) IngestBatch(samples []LocationSample) error {
+	return e.ingest(samples, true)
+}
+
+func (e *Engine) ingest(samples []LocationSample, logToWAL bool) error {
+	for i := range samples {
+		if err := validateSample(samples[i]); err != nil {
+			return err
+		}
+	}
+
+	if logToWAL && e.wal != nil {
+		if err := e.wal.Append(samples); err != nil {
+			return err
+		}
+	}
+
+	res := e.cfg.DefaultResolution
+	res = e.clampResolution(res)
+
+	for i := range samples {
+		sample := samples[i]
+		cellID, err := e.cellIndex.CellForCoord(sample.Lat, sample.Lon, res)
+		if err != nil {
+			return err
+		}
+
+		e.nodes.Update(cellID, res, sample)
+
+		prev, ok := e.states.Get(sample.EntityID)
+		if ok {
+			if prev.LastCell != cellID {
+				delta := sample.Timestamp.Sub(prev.LastTime)
+				e.transitions.Update(prev.LastCell, cellID, res, delta, sample.Timestamp)
+			}
+		}
+		e.states.Update(sample.EntityID, cellID, sample.Timestamp)
+	}
+
+	return nil
+}
+
+// QueryStigmaMap returns aggregates for the query bounds.
+func (e *Engine) QueryStigmaMap(q StigmaMapQuery) (StigmaMap, error) {
+	res := e.cfg.DefaultResolution
+	if q.Resolution != nil {
+		res = e.clampResolution(*q.Resolution)
+	} else {
+		res = e.clampResolution(res)
+	}
+
+	cells, err := e.cellIndex.CellsInBBox(q.MinLat, q.MinLon, q.MaxLat, q.MaxLon, res)
+	if err != nil {
+		return StigmaMap{}, err
+	}
+
+	cellSet := make(map[CellID]struct{}, len(cells))
+	for _, c := range cells {
+		cellSet[c] = struct{}{}
+	}
+
+	nodes := e.nodes.TimeFiltered(q.StartTime, q.EndTime)
+	filteredNodes := make([]NodeAggregate, 0, len(nodes))
+	for _, n := range nodes {
+		if _, ok := cellSet[n.CellID]; !ok {
+			continue
+		}
+		if q.MinSampleCount > 0 && n.SampleCount < q.MinSampleCount {
+			continue
+		}
+		filteredNodes = append(filteredNodes, n)
+	}
+
+	result := StigmaMap{Nodes: filteredNodes}
+	if q.IncludeTransitions {
+		result.Transitions = e.transitions.FilterByCells(cellSet, q.StartTime, q.EndTime)
+	}
+
+	return result, nil
+}
+
+// GetCellStats returns aggregate for a single cell.
+func (e *Engine) GetCellStats(cellID CellID) (NodeAggregate, bool) {
+	return e.nodes.Get(cellID)
+}
+
+// GetEntityPathSummary returns visitation summary for an entity.
+func (e *Engine) GetEntityPathSummary(entityID string) (EntityPathSummary, bool) {
+	return e.states.PathSummary(entityID)
+}
+
+func (e *Engine) replayWAL() error {
+	entries, err := e.wal.ReadAll()
+	if err != nil {
+		return err
+	}
+	return e.ingest(entries, false)
+}

--- a/stigma/engine_test.go
+++ b/stigma/engine_test.go
@@ -1,0 +1,119 @@
+package stigma
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestIngestSingleSampleUpdatesNode(t *testing.T) {
+	engine, err := NewEngine(EngineConfig{DefaultResolution: 1})
+	if err != nil {
+		t.Fatalf("failed to create engine: %v", err)
+	}
+	now := time.Now().UTC()
+	sample := LocationSample{EntityID: "e1", Lat: 1.0, Lon: 1.0, Timestamp: now, SpeedMps: 2.5}
+	if err := engine.IngestSample(sample); err != nil {
+		t.Fatalf("ingest sample: %v", err)
+	}
+
+	cell, _ := engine.cellIndex.CellForCoord(sample.Lat, sample.Lon, engine.cfg.DefaultResolution)
+	agg, ok := engine.GetCellStats(cell)
+	if !ok {
+		t.Fatalf("expected cell aggregate present")
+	}
+	if agg.SampleCount != 1 || agg.UniqueEntities != 1 {
+		t.Fatalf("unexpected counts: %+v", agg)
+	}
+	if agg.MaxSpeedMps != sample.SpeedMps || agg.AvgSpeedMps == 0 {
+		t.Fatalf("unexpected speed aggregates: %+v", agg)
+	}
+}
+
+func TestTransitionComputedAcrossCells(t *testing.T) {
+	engine, _ := NewEngine(EngineConfig{DefaultResolution: 1})
+	now := time.Now().UTC()
+	samples := []LocationSample{
+		{EntityID: "e1", Lat: 0, Lon: 0, Timestamp: now},
+		{EntityID: "e1", Lat: 10, Lon: 10, Timestamp: now.Add(10 * time.Second)},
+	}
+	if err := engine.IngestBatch(samples); err != nil {
+		t.Fatalf("ingest batch: %v", err)
+	}
+
+	transitions := engine.transitions.All()
+	if len(transitions) != 1 {
+		t.Fatalf("expected one transition, got %d", len(transitions))
+	}
+	tr := transitions[0]
+	if tr.TransitionCount != 1 || tr.AvgTravelTime != 10*time.Second || tr.MinTravelTime != 10*time.Second || tr.MaxTravelTime != 10*time.Second {
+		t.Fatalf("unexpected transition aggregate: %+v", tr)
+	}
+}
+
+func TestQueryStigmaMapFiltersBySampleCount(t *testing.T) {
+	engine, _ := NewEngine(EngineConfig{DefaultResolution: 1})
+	now := time.Now().UTC()
+	_ = engine.IngestBatch([]LocationSample{
+		{EntityID: "a", Lat: 0, Lon: 0, Timestamp: now},
+		{EntityID: "a", Lat: 0, Lon: 0, Timestamp: now.Add(time.Second)},
+		{EntityID: "b", Lat: 1, Lon: 1, Timestamp: now},
+	})
+
+	query := StigmaMapQuery{MinLat: -1, MinLon: -1, MaxLat: 2, MaxLon: 2, MinSampleCount: 2}
+	result, err := engine.QueryStigmaMap(query)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+
+	if len(result.Nodes) != 1 {
+		t.Fatalf("expected one node after filtering, got %d", len(result.Nodes))
+	}
+}
+
+func TestWALReplayRestoresAggregates(t *testing.T) {
+	dir := t.TempDir()
+	walPath := filepath.Join(dir, "wal.log")
+
+	cfg := EngineConfig{DefaultResolution: 1, WALPath: walPath}
+	engine, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("create engine: %v", err)
+	}
+	now := time.Now().UTC()
+	if err := engine.IngestSample(LocationSample{EntityID: "x", Lat: 1, Lon: 1, Timestamp: now}); err != nil {
+		t.Fatalf("ingest with wal: %v", err)
+	}
+	_ = engine.Close()
+
+	// reopen and ensure sample is replayed
+	engine2, err := NewEngine(cfg)
+	if err != nil {
+		t.Fatalf("recreate engine: %v", err)
+	}
+	defer engine2.Close()
+
+	cell, _ := engine2.cellIndex.CellForCoord(1, 1, cfg.DefaultResolution)
+	if agg, ok := engine2.GetCellStats(cell); !ok || agg.SampleCount != 1 {
+		t.Fatalf("expected aggregate restored, got %#v", agg)
+	}
+
+	// ensure wal file exists
+	if _, err := os.Stat(walPath); err != nil {
+		t.Fatalf("wal file missing: %v", err)
+	}
+}
+
+func TestInvalidSamplesReturnErrors(t *testing.T) {
+	engine, _ := NewEngine(EngineConfig{DefaultResolution: 1})
+	err := engine.IngestSample(LocationSample{})
+	if err == nil {
+		t.Fatalf("expected validation error")
+	}
+
+	err = engine.IngestSample(LocationSample{EntityID: "a", Lat: -91, Lon: 0, Timestamp: time.Now()})
+	if err == nil {
+		t.Fatalf("expected invalid coordinate error")
+	}
+}

--- a/stigma/entity_state.go
+++ b/stigma/entity_state.go
@@ -1,0 +1,60 @@
+package stigma
+
+import "time"
+
+type entityState struct {
+	EntityID  string
+	LastCell  CellID
+	LastTime  time.Time
+	FirstTime time.Time
+	visited   map[CellID]struct{}
+}
+
+// EntityStateStore tracks last seen state per entity.
+type EntityStateStore struct {
+	states map[string]*entityState
+}
+
+// NewEntityStateStore constructs the store.
+func NewEntityStateStore() *EntityStateStore {
+	return &EntityStateStore{states: make(map[string]*entityState)}
+}
+
+// Update records the latest cell and timestamp for an entity.
+func (s *EntityStateStore) Update(entityID string, cell CellID, ts time.Time) *entityState {
+	state, ok := s.states[entityID]
+	if !ok {
+		state = &entityState{EntityID: entityID, FirstTime: ts, visited: make(map[CellID]struct{})}
+		s.states[entityID] = state
+	}
+	state.LastCell = cell
+	state.LastTime = ts
+	state.visited[cell] = struct{}{}
+	return state
+}
+
+// Get returns the current state for an entity.
+func (s *EntityStateStore) Get(entityID string) (*entityState, bool) {
+	st, ok := s.states[entityID]
+	return st, ok
+}
+
+// PathSummary returns a snapshot of path information.
+func (s *EntityStateStore) PathSummary(entityID string) (EntityPathSummary, bool) {
+	st, ok := s.states[entityID]
+	if !ok {
+		return EntityPathSummary{}, false
+	}
+
+	cells := make([]CellID, 0, len(st.visited))
+	for cell := range st.visited {
+		cells = append(cells, cell)
+	}
+
+	return EntityPathSummary{
+		EntityID:  entityID,
+		FirstSeen: st.FirstTime,
+		LastSeen:  st.LastTime,
+		Cells:     cells,
+	}, true
+}

--- a/stigma/nodestore.go
+++ b/stigma/nodestore.go
@@ -1,0 +1,100 @@
+package stigma
+
+import "time"
+
+type nodeMetrics struct {
+	agg          NodeAggregate
+	entityIDs    map[string]struct{}
+	speedSum     float64
+	speedSamples uint64
+}
+
+// NodeStore aggregates samples per cell.
+type NodeStore struct {
+	nodes map[CellID]*nodeMetrics
+}
+
+// NewNodeStore constructs NodeStore.
+func NewNodeStore() *NodeStore {
+	return &NodeStore{nodes: make(map[CellID]*nodeMetrics)}
+}
+
+// Update updates aggregates for a cell and entity.
+func (s *NodeStore) Update(cell CellID, res Resolution, sample LocationSample) NodeAggregate {
+	n, ok := s.nodes[cell]
+	if !ok {
+		n = &nodeMetrics{
+			agg:       NodeAggregate{CellID: cell, Resolution: res},
+			entityIDs: make(map[string]struct{}),
+		}
+		s.nodes[cell] = n
+	}
+
+	n.agg.SampleCount++
+	if _, seen := n.entityIDs[sample.EntityID]; !seen {
+		n.entityIDs[sample.EntityID] = struct{}{}
+		n.agg.UniqueEntities = uint64(len(n.entityIDs))
+	}
+
+	if n.agg.FirstSeen.IsZero() || sample.Timestamp.Before(n.agg.FirstSeen) {
+		n.agg.FirstSeen = sample.Timestamp
+	}
+	if sample.Timestamp.After(n.agg.LastSeen) {
+		n.agg.LastSeen = sample.Timestamp
+	}
+
+	if sample.SpeedMps > 0 {
+		n.speedSum += float64(sample.SpeedMps)
+		n.speedSamples++
+		n.agg.AvgSpeedMps = float32(n.speedSum / float64(n.speedSamples))
+		if sample.SpeedMps > n.agg.MaxSpeedMps {
+			n.agg.MaxSpeedMps = sample.SpeedMps
+		}
+	}
+
+	return n.agg
+}
+
+// Get returns the aggregate for a cell.
+func (s *NodeStore) Get(cell CellID) (NodeAggregate, bool) {
+	n, ok := s.nodes[cell]
+	if !ok {
+		return NodeAggregate{}, false
+	}
+	return n.agg, true
+}
+
+// All returns all aggregates.
+func (s *NodeStore) All() []NodeAggregate {
+	res := make([]NodeAggregate, 0, len(s.nodes))
+	for _, n := range s.nodes {
+		res = append(res, n.agg)
+	}
+	return res
+}
+
+// PruneMinSample filters nodes by sample count.
+func (s *NodeStore) PruneMinSample(min uint64) []NodeAggregate {
+	res := make([]NodeAggregate, 0)
+	for _, n := range s.nodes {
+		if n.agg.SampleCount >= min {
+			res = append(res, n.agg)
+		}
+	}
+	return res
+}
+
+// TimeFiltered returns nodes matching coarse time criteria.
+func (s *NodeStore) TimeFiltered(start, end *time.Time) []NodeAggregate {
+	res := make([]NodeAggregate, 0)
+	for _, n := range s.nodes {
+		if start != nil && n.agg.LastSeen.Before(*start) {
+			continue
+		}
+		if end != nil && n.agg.FirstSeen.After(*end) {
+			continue
+		}
+		res = append(res, n.agg)
+	}
+	return res
+}

--- a/stigma/server/http_server.go
+++ b/stigma/server/http_server.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+
+	"github.com/fabricekabongo/loggerhead/stigma"
+)
+
+// HTTPServer provides minimal wrappers around the stigma engine.
+type HTTPServer struct {
+	engine *stigma.Engine
+}
+
+// NewHTTPServer constructs the server.
+func NewHTTPServer(engine *stigma.Engine) *HTTPServer {
+	return &HTTPServer{engine: engine}
+}
+
+// ServeHTTP dispatches requests.
+func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Path {
+	case "/ingest":
+		s.handleIngest(w, r)
+	case "/query/stigma-map":
+		s.handleQuery(w, r)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *HTTPServer) handleIngest(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var samples []stigma.LocationSample
+	if err := json.NewDecoder(r.Body).Decode(&samples); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.engine.IngestBatch(samples); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (s *HTTPServer) handleQuery(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var q stigma.StigmaMapQuery
+	if err := json.NewDecoder(r.Body).Decode(&q); err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	res, err := s.engine.QueryStigmaMap(q)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := json.NewEncoder(w).Encode(res); err != nil {
+		log.Println("failed to encode response", err)
+	}
+}

--- a/stigma/transitionstore.go
+++ b/stigma/transitionstore.go
@@ -1,0 +1,76 @@
+package stigma
+
+import "time"
+
+type transitionMetrics struct {
+	agg       TransitionAggregate
+	travelSum time.Duration
+}
+
+// TransitionStore aggregates movements between cells.
+type TransitionStore struct {
+	transitions map[TransitionKey]*transitionMetrics
+}
+
+// NewTransitionStore constructs the store.
+func NewTransitionStore() *TransitionStore {
+	return &TransitionStore{transitions: make(map[TransitionKey]*transitionMetrics)}
+}
+
+// Update updates the aggregate for a transition.
+func (s *TransitionStore) Update(from, to CellID, res Resolution, delta time.Duration, ts time.Time) TransitionAggregate {
+	key := TransitionKey{FromCell: from, ToCell: to}
+	t, ok := s.transitions[key]
+	if !ok {
+		t = &transitionMetrics{agg: TransitionAggregate{FromCell: from, ToCell: to, Resolution: res}}
+		s.transitions[key] = t
+	}
+
+	t.agg.TransitionCount++
+	t.travelSum += delta
+	avg := t.travelSum / time.Duration(t.agg.TransitionCount)
+	t.agg.AvgTravelTime = avg
+	if t.agg.MinTravelTime == 0 || delta < t.agg.MinTravelTime {
+		t.agg.MinTravelTime = delta
+	}
+	if delta > t.agg.MaxTravelTime {
+		t.agg.MaxTravelTime = delta
+	}
+	if ts.After(t.agg.LastSeen) {
+		t.agg.LastSeen = ts
+	}
+
+	return t.agg
+}
+
+// All returns all transition aggregates.
+func (s *TransitionStore) All() []TransitionAggregate {
+	res := make([]TransitionAggregate, 0, len(s.transitions))
+	for _, t := range s.transitions {
+		res = append(res, t.agg)
+	}
+	return res
+}
+
+// FilterByCells returns transitions whose endpoints are in the provided set.
+func (s *TransitionStore) FilterByCells(cells map[CellID]struct{}, start, end *time.Time) []TransitionAggregate {
+	res := make([]TransitionAggregate, 0)
+	for key, t := range s.transitions {
+		if _, ok := cells[key.FromCell]; !ok {
+			continue
+		}
+		if _, ok := cells[key.ToCell]; !ok {
+			continue
+		}
+		if start != nil && t.agg.LastSeen.Before(*start) {
+			continue
+		}
+		if end != nil && t.agg.LastSeen.After(*end) {
+			// transitions are coarse filtered; keep if last seen before end
+			// otherwise skip
+			continue
+		}
+		res = append(res, t.agg)
+	}
+	return res
+}

--- a/stigma/types.go
+++ b/stigma/types.go
@@ -1,0 +1,92 @@
+package stigma
+
+import "time"
+
+// LocationSample represents one geospatial observation for an entity.
+type LocationSample struct {
+	EntityID   string            // required
+	Lat        float64           // degrees
+	Lon        float64           // degrees
+	Timestamp  time.Time         // required, UTC
+	SpeedMps   float32           // optional, meters per second (0 if unknown)
+	HeadingDeg float32           // optional, 0-360 (0 if unknown)
+	Attrs      map[string]string // optional, extra tags (version, appID, etc.)
+}
+
+// CellID references a grid cell.
+type CellID uint64
+
+// Resolution represents the granularity of the grid (similar to H3 resolutions).
+type Resolution int
+
+// NodeAggregate holds aggregate metrics for a cell.
+type NodeAggregate struct {
+	CellID     CellID
+	Resolution Resolution
+
+	// Counts
+	SampleCount    uint64 // total samples in this cell
+	UniqueEntities uint64 // distinct entities seen
+
+	// Temporal stats
+	FirstSeen time.Time
+	LastSeen  time.Time
+
+	// Motion stats
+	AvgSpeedMps float32 // average speed of samples in cell
+	MaxSpeedMps float32 // max speed observed
+}
+
+// TransitionKey identifies a movement between two cells.
+type TransitionKey struct {
+	FromCell CellID
+	ToCell   CellID
+}
+
+// TransitionAggregate stores metrics for movements between two cells.
+type TransitionAggregate struct {
+	FromCell   CellID
+	ToCell     CellID
+	Resolution Resolution
+
+	TransitionCount uint64
+	AvgTravelTime   time.Duration
+	MinTravelTime   time.Duration
+	MaxTravelTime   time.Duration
+	LastSeen        time.Time
+}
+
+// StigmaMapQuery defines the parameters for querying aggregates.
+type StigmaMapQuery struct {
+	// Spatial
+	MinLat float64
+	MinLon float64
+	MaxLat float64
+	MaxLon float64
+
+	// When empty, use engine default
+	Resolution *Resolution
+
+	// Temporal filter (optional)
+	StartTime *time.Time
+	EndTime   *time.Time
+
+	// Flags to control what to include
+	IncludeTransitions bool
+	MinSampleCount     uint64 // filter out low-density nodes
+}
+
+// StigmaMap is the result of a query.
+type StigmaMap struct {
+	Nodes       []NodeAggregate
+	Transitions []TransitionAggregate
+}
+
+// EntityPathSummary summarizes one entity's historical visits.
+type EntityPathSummary struct {
+	EntityID string
+
+	FirstSeen time.Time
+	LastSeen  time.Time
+	Cells     []CellID // distinct visited cells (order not guaranteed in v1)
+}

--- a/stigma/wal.go
+++ b/stigma/wal.go
@@ -1,0 +1,80 @@
+package stigma
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"sync"
+)
+
+// WAL is a simple append-only log of samples.
+type WAL struct {
+	path string
+	file *os.File
+	enc  *json.Encoder
+	mu   sync.Mutex
+}
+
+// OpenWAL opens or creates the WAL at the path.
+func OpenWAL(path string) (*WAL, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, err
+	}
+	// move to end for appends
+	if _, err := file.Seek(0, io.SeekEnd); err != nil {
+		file.Close()
+		return nil, err
+	}
+
+	return &WAL{path: path, file: file, enc: json.NewEncoder(file)}, nil
+}
+
+// Append writes samples to the log.
+func (w *WAL) Append(samples []LocationSample) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for _, s := range samples {
+		if err := w.enc.Encode(&s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ReadAll replays all entries from the beginning.
+func (w *WAL) ReadAll() ([]LocationSample, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if _, err := w.file.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+
+	dec := json.NewDecoder(w.file)
+	var entries []LocationSample
+	for {
+		var s LocationSample
+		if err := dec.Decode(&s); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, err
+		}
+		entries = append(entries, s)
+	}
+
+	// return file to end for future appends
+	if _, err := w.file.Seek(0, io.SeekEnd); err != nil {
+		return nil, err
+	}
+
+	return entries, nil
+}
+
+// Close closes the WAL file.
+func (w *WAL) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.file.Close()
+}


### PR DESCRIPTION
## Summary
- add a new stigma package with cell indexing, ingest pipeline, and aggregate stores
- implement simple WAL persistence and a minimal HTTP wrapper
- cover ingest, transition, query, and WAL replay behaviors with unit tests

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69240262b2f48333a1155151b197fcfe)